### PR TITLE
Remove .api from device name

### DIFF
--- a/src/main/java/brickhouse/udf/json/GetDeviceUDF.java
+++ b/src/main/java/brickhouse/udf/json/GetDeviceUDF.java
@@ -18,11 +18,8 @@ import org.apache.hadoop.hive.ql.exec.UDF;
          if(compare(source, "desktop"))
             return "web";
 
-         if(compare(source, "mobile"))
-            return source;
-
          if(source != null)
-            return "api." + source;
+            return source;
 
          if(os == null ||
             os.equalsIgnoreCase("null") ||

--- a/src/test/java/brickhouse/analytics/uniques/SketchSetTest.java
+++ b/src/test/java/brickhouse/analytics/uniques/SketchSetTest.java
@@ -423,7 +423,7 @@ public class SketchSetTest {
 		GetDeviceUDF test = new GetDeviceUDF();
 		String result = test.evaluate("Windows 8", "mobile-app");
 		System.out.println(result);
-		Assert.assertTrue(result.equals("api.mobile-app"));
+		Assert.assertTrue(result.equals("mobile-app"));
 	}
 
 	@Test


### PR DESCRIPTION
Request para remover o '.api' na conversão de nomes dos devices.